### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ unittest2
 coverage
 enum34
 jsonpickle
+traceback2


### PR DESCRIPTION
sudo pip install -r requirements.txt + make test geeft error: "No module named traceback2"; na 'pip install traceback2' is het in orde. 
misschien bij opnemen in requirements.txt?