### PR TITLE
Prevent unsolicited_response_logger from going 100% cpu

### DIFF
--- a/examples/unsolicited_response_logger.py
+++ b/examples/unsolicited_response_logger.py
@@ -27,6 +27,7 @@ import argparse
 
 import logging
 import sys
+import time
 
 from d7a.alp.command import Command
 from d7a.alp.interface import InterfaceType
@@ -62,6 +63,7 @@ modem.connect()
 
 try:
   while True:
+    time.sleep(0.1)
     pass
 except KeyboardInterrupt:
   sys.exit(0)


### PR DESCRIPTION
All the work is done in another thread, so the main thread can sleep.